### PR TITLE
Func name update | Return false on any env except 'production'

### DIFF
--- a/wp-indexing.php
+++ b/wp-indexing.php
@@ -9,12 +9,10 @@ Author URI:   http://github.com/emaildano
 License:      MIT License
 */
 
-add_action( 'wp_loaded', 'wp_indexing' );
+add_action( 'wp_loaded', 'J2made_wp_indexing' );
 
-function wp_indexing() {
+function J2made_wp_indexing() {
   if (WP_ENV !== 'production') {
-    update_option( 'blog_public', '1' );
-  } else {
     update_option( 'blog_public', '0' );
   }
 }


### PR DESCRIPTION
- updated function name so it does not have 'wp_' prefix.
- function now returns false if the env var is anything other than production. Allows the option to be set in WP backend by user.
